### PR TITLE
Fixes to work on modern rubies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,54 @@
-.idea
-rubywarrior
-Gemfile.lock
-/pkg
+
+# Created by https://www.gitignore.io/api/ruby
+
+### Ruby ###
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc

--- a/ruby_armor.gemspec
+++ b/ruby_armor.gemspec
@@ -1,44 +1,28 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = "ruby_armor"
-  s.version = "0.0.5alpha"
+  s.name = 'ruby_armor'
+  s.version = '0.0.6alpha'
 
-  s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Bil Bas (Spooner)"]
-  s.date = "2012-02-27"
-  s.email = ["bil.bagpuss@gmail.com"]
-  s.executables = ["ruby_armor"]
-  s.files = ["config/default_config.yml", "config/gui", "config/gui/schema.yml", "lib/ruby_armor", "lib/ruby_armor/base_user_data.rb", "lib/ruby_armor/floating_text.rb", "lib/ruby_armor/ruby_warrior_ext", "lib/ruby_armor/ruby_warrior_ext/abilities", "lib/ruby_armor/ruby_warrior_ext/abilities/rest.rb", "lib/ruby_armor/ruby_warrior_ext/position.rb", "lib/ruby_armor/ruby_warrior_ext/ui.rb", "lib/ruby_armor/ruby_warrior_ext/units", "lib/ruby_armor/ruby_warrior_ext/units/base.rb", "lib/ruby_armor/sprite_sheet.rb", "lib/ruby_armor/states", "lib/ruby_armor/states/choose_profile.rb", "lib/ruby_armor/states/play.rb", "lib/ruby_armor/states/review_code.rb", "lib/ruby_armor/version.rb", "lib/ruby_armor/warrior_config.rb", "lib/ruby_armor/window.rb", "lib/ruby_armor.rb", "media/fonts", "media/fonts/Licence.txt", "media/fonts/ProggyCleanSZ.ttf", "media/images", "media/images/mobs.png", "media/images/tiles.png", "media/images/warriors.png", "README.md", "bin/ruby_armor"]
-  s.homepage = "http://spooner.github.com/libraries/ruby_armor/"
-  s.licenses = ["MIT"]
-  s.require_paths = ["lib"]
-  s.required_ruby_version = Gem::Requirement.new("~> 1.9.2")
-  s.rubyforge_project = "ruby_armor"
-  s.rubygems_version = "1.8.16"
-  s.summary = "GUI interface for RubyWarrior"
+  s.required_rubygems_version = Gem::Requirement.new('> 1.3.1') if s.respond_to? :required_rubygems_version=
+  s.authors = ['Bil Bas (Spooner)']
+  s.date = '2012-02-27'
+  s.email = ['bil.bagpuss@gmail.com']
+  s.executables = ['ruby_armor']
+  s.files         = `git ls-files`.split("\n")
+  s.license       = 'MIT'
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
+  s.homepage = 'http://spooner.github.com/libraries/ruby_armor/'
+  s.licenses = ['MIT']
+  s.require_paths = ['lib']
+  s.required_ruby_version = Gem::Requirement.new('>= 1.9.2')
+  s.rubyforge_project = 'ruby_armor'
+  s.rubygems_version = '1.8.16'
+  s.summary = 'GUI interface for RubyWarrior'
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rubywarrior>, ["~> 0.1.2"])
-      s.add_runtime_dependency(%q<gosu>, ["~> 0.7.41"])
-      s.add_runtime_dependency(%q<chingu>, ["~> 0.9rc7"])
-      s.add_runtime_dependency(%q<fidgit>, ["~> 0.2.4"])
-      s.add_development_dependency(%q<releasy>, ["~> 0.2.2"])
-    else
-      s.add_dependency(%q<rubywarrior>, ["~> 0.1.2"])
-      s.add_dependency(%q<gosu>, ["~> 0.7.41"])
-      s.add_dependency(%q<chingu>, ["~> 0.9rc7"])
-      s.add_dependency(%q<fidgit>, ["~> 0.2.4"])
-      s.add_dependency(%q<releasy>, ["~> 0.2.2"])
-    end
-  else
-    s.add_dependency(%q<rubywarrior>, ["~> 0.1.2"])
-    s.add_dependency(%q<gosu>, ["~> 0.7.41"])
-    s.add_dependency(%q<chingu>, ["~> 0.9rc7"])
-    s.add_dependency(%q<fidgit>, ["~> 0.2.4"])
-    s.add_dependency(%q<releasy>, ["~> 0.2.2"])
-  end
+  s.add_runtime_dependency('rubywarrior', ['~> 0.1', '>= 0.1.2'])
+  s.add_runtime_dependency('gosu', ['~> 0.10', '>= 0.7.41'])
+  s.add_runtime_dependency('chingu', ['~> 0.9rc9'])
+  s.add_runtime_dependency('fidgit', ['~> 0.2', '>= 0.2.7'])
+  s.add_development_dependency('releasy', ['~> 0.2', '>= 0.2.2'])
 end


### PR DESCRIPTION
Fixed the Ruby version constraint to allow Ruby 2.x, relaxed version constraints where too restrictive, removed workarounds for ancient rubygems versions.

Tested on macOS Sierra with Ruby 2.3.1
